### PR TITLE
Fix array shapes of AndroidConfig

### DIFF
--- a/src/Firebase/Messaging/AndroidConfig.php
+++ b/src/Firebase/Messaging/AndroidConfig.php
@@ -18,7 +18,7 @@ final class AndroidConfig implements JsonSerializable
     /** @var array{
      *      collapse_key?: string,
      *      priority?: 'normal'|'high',
-     *      ttl?: int|double,
+     *      ttl?: string,
      *      restricted_package_name?: string,
      *      data?: array<string, string>,
      *      notification?: array<string, string>,
@@ -32,7 +32,7 @@ final class AndroidConfig implements JsonSerializable
      * @param array{
      *     collapse_key?: string,
      *     priority?: 'normal'|'high',
-     *     ttl?: int|double,
+     *     ttl?: string,
      *     restricted_package_name?: string,
      *     data?: array<string, string>,
      *     notification?: array<string, string>,


### PR DESCRIPTION
The TTL has to be defined as "string" (Duration) instead of "int|double" as mentioned in referenced documentation https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidconfig